### PR TITLE
fix: ignore rating toggle deselection instead of saving an empty rating

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: bump-version
+description: Bump the knowledgebuilder app version across package.json and both environment files, refresh the release date, verify the build, and optionally create a release commit. Invoke when the user asks to bump/release/version the app.
+---
+
+# Bump Version
+
+The version string lives in **three** places that must stay in sync, plus a `releasedate` field in the two environment files:
+
+| File | Field(s) |
+|---|---|
+| `package.json` | `version` |
+| `src/environments/environment.ts` | `version`, `releasedate` |
+| `src/environments/environment.prod.ts` | `version`, `releasedate` |
+
+The footer (`src/app/shared/footer`) displays both `version` and `releasedate`.
+
+## Version scheme
+
+Semver `MAJOR.MINOR.PATCH` (e.g. `1.8.419`). PATCH is a running number, not strictly +1 - always confirm the target with the user.
+
+## Steps
+
+1. **Determine the target version.** If the user gave an explicit version (e.g. `1.8.420`), use it. Otherwise ask whether to bump `patch` / `minor` / `major` and compute it from the current `package.json` version.
+2. **Apply the bump** by running the helper script that ships with this skill - never edit the version fields by hand, so the three files cannot drift:
+   ```bash
+   node .claude/skills/bump-version/bump-version.mjs <X.Y.Z>
+   ```
+   This updates `package.json`, both environment files, and sets `releasedate` to today's date (`YYYY-MM-DD`).
+3. **Verify sync** - confirm all three files report the same version:
+   ```bash
+   grep -nE "version|releasedate" package.json src/environments/environment.ts src/environments/environment.prod.ts
+   ```
+4. **Verify the build** (recommended):
+   ```bash
+   ng build --configuration development
+   ```
+5. **Commit only if the user explicitly asks.** Follow the repo convention from git history:
+   ```
+   chore: bump version to <X.Y.Z>
+   ```
+   Stage `package.json`, `src/environments/environment.ts`, `src/environments/environment.prod.ts`. Per project rules, never commit unless requested.
+
+## Notes
+
+- If the user also wants a git tag, the repo currently has no tagging convention - ask first.
+- The helper script lives next to this file at `.claude/skills/bump-version/bump-version.mjs` so the skill is self-contained.

--- a/.claude/skills/bump-version/bump-version.mjs
+++ b/.claude/skills/bump-version/bump-version.mjs
@@ -1,0 +1,33 @@
+// Bumps the project version in all three locations and refreshes the release date.
+// Usage: node .claude/skills/bump-version/bump-version.mjs <X.Y.Z>
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const newVersion = process.argv[2];
+if (!newVersion || !/^\d+\.\d+\.\d+$/.test(newVersion)) {
+  console.error('Usage: node .claude/skills/bump-version/bump-version.mjs <X.Y.Z>');
+  process.exit(1);
+}
+
+const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+// 1. package.json
+const pkgPath = 'package.json';
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const oldVersion = pkg.version;
+pkg.version = newVersion;
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+// 2 & 3. environment files - update version + releasedate
+const envFiles = [
+  'src/environments/environment.ts',
+  'src/environments/environment.prod.ts',
+];
+for (const p of envFiles) {
+  let txt = readFileSync(p, 'utf8');
+  txt = txt.replace(/(version\s*:\s*)'[^']*'/, `$1'${newVersion}'`);
+  txt = txt.replace(/(releasedate\s*:\s*)'[^']*'/, `$1'${today}'`);
+  writeFileSync(p, txt);
+}
+
+console.log(`Bumped ${oldVersion} -> ${newVersion} (releasedate ${today})`);
+console.log('Updated: package.json, environment.ts, environment.prod.ts');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledgebuilder",
-  "version": "1.8.422",
+  "version": "1.8.423",
   "license": "MIT",
   "description": "An AI-powered web-based Learning app for English, Chinese, and Knowledge Bank part.",
   "author": {

--- a/src/app/pages/chinese-exercises/chinese-exercises.component.spec.ts
+++ b/src/app/pages/chinese-exercises/chinese-exercises.component.spec.ts
@@ -696,6 +696,31 @@ describe('ChineseExercisesComponent', () => {
       expect(component.selection.selected.length).toBe(initialCount);
     });
   });
+
+  describe('onContentRatingChanged', () => {
+    it('should save the rating via upsertRating when a level is chosen', () => {
+      ratingServiceSpy.upsertRating.mockReturnValue(of({ contentId: 1, itemId: 10, rating: 3 }));
+      component.studyContentId = 1;
+      const event = { value: 3, source: { value: 3, buttonToggleGroup: { value: 3 } } } as any;
+
+      component.onContentRatingChanged({ id: 10 } as any, event);
+
+      expect(ratingServiceSpy.upsertRating).toHaveBeenCalledWith(1, 10, 3);
+    });
+
+    it('should not save and should restore the previous selection when the toggle is deselected', () => {
+      // Clicking the active toggle in a mat-button-toggle-group deselects it,
+      // emitting change with value undefined.
+      component.studyContentId = 1;
+      const group = { value: undefined as unknown };
+      const event = { value: undefined, source: { value: 3, buttonToggleGroup: group } } as any;
+
+      component.onContentRatingChanged({ id: 10 } as any, event);
+
+      expect(ratingServiceSpy.upsertRating).not.toHaveBeenCalled();
+      expect(group.value).toBe(3);
+    });
+  });
 });
 
 describe('ChineseExercisesOptionsDialogComponent', () => {

--- a/src/app/pages/chinese-exercises/chinese-exercises.component.ts
+++ b/src/app/pages/chinese-exercises/chinese-exercises.component.ts
@@ -303,7 +303,13 @@ export class ChineseExercisesComponent implements OnInit {
   }
 
   onContentRatingChanged(item: LearnChineseFileItem, event: MatButtonToggleChange) {
-    if (this.studyContentId <= 0 || item.id === undefined || event.value < 1) {
+    if (event.value === undefined || event.value === null || event.value < 1) {
+      // Clicking the active toggle deselects it (value becomes undefined).
+      // There is no "clear rating" operation, so restore the previous selection.
+      event.source.buttonToggleGroup.value = event.source.value;
+      return;
+    }
+    if (this.studyContentId <= 0 || item.id === undefined) {
       return;
     }
 

--- a/src/app/pages/knowledge-exercises/knowledge-exercises-list/knowledge-exercises-list.component.spec.ts
+++ b/src/app/pages/knowledge-exercises/knowledge-exercises-list/knowledge-exercises-list.component.spec.ts
@@ -32,6 +32,7 @@ import { vi } from 'vitest';
 import type { KnowledgeExerciseFileContent, LearningContent } from '../../../interfaces';
 import { QuestionBankTypeEnum, RatingOperatorEnum } from '../../../interfaces';
 import { LearningContentService } from '../../../services/learning-content.service';
+import { LearningRatingService } from '../../../services/learning-rating.service';
 import { UIService } from '../../../services/ui.service';
 import { FooterComponent } from '../../../shared/footer/footer';
 import { MarkdownContentComponent } from '../../../shared/markdown-content';
@@ -1088,6 +1089,23 @@ describe('KnowledgeExercisesListComponent', () => {
         true,
         undefined
       );
+    });
+  });
+
+  describe('onContentRatingChanged', () => {
+    it('should not save and should restore the previous selection when the toggle is deselected', () => {
+      // Clicking the active toggle in a mat-button-toggle-group deselects it,
+      // emitting change with value undefined.
+      const ratingService = TestBed.inject(LearningRatingService);
+      const upsertSpy = vi.spyOn(ratingService, 'upsertRating');
+      (component as any).currentContentId = 1;
+      const group = { value: undefined as unknown };
+      const event = { value: undefined, source: { value: 2, buttonToggleGroup: group } } as any;
+
+      component.onContentRatingChanged({ id: '10' } as any, event);
+
+      expect(upsertSpy).not.toHaveBeenCalled();
+      expect(group.value).toBe(2);
     });
   });
 });

--- a/src/app/pages/knowledge-exercises/knowledge-exercises-list/knowledge-exercises-list.component.ts
+++ b/src/app/pages/knowledge-exercises/knowledge-exercises-list/knowledge-exercises-list.component.ts
@@ -290,7 +290,13 @@ export class KnowledgeExercisesListComponent implements OnInit {
   }
 
   onContentRatingChanged(item: KnowledgeExerciseFileContent, event: MatButtonToggleChange) {
-    if (this.currentContentId === undefined || item.id === undefined || event.value < 1) {
+    if (event.value === undefined || event.value === null || event.value < 1) {
+      // Clicking the active toggle deselects it (value becomes undefined).
+      // There is no "clear rating" operation, so restore the previous selection.
+      event.source.buttonToggleGroup.value = event.source.value;
+      return;
+    }
+    if (this.currentContentId === undefined || item.id === undefined) {
       return;
     }
     const numId = parseInt(item.id, 10);

--- a/src/app/pages/translate-exercises/translate-exercises.component.spec.ts
+++ b/src/app/pages/translate-exercises/translate-exercises.component.spec.ts
@@ -28,6 +28,7 @@ import {
   UserCodeService,
   UIService,
 } from '../../services';
+import { LearningRatingService } from '../../services/learning-rating.service';
 import { AppPageTitle } from '../page-title/page-title';
 
 import {
@@ -754,6 +755,23 @@ describe('TranslateExercisesComponent', () => {
       component.onSelectByRating();
 
       expect(markForCheckSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onContentRatingChanged', () => {
+    it('should not save and should restore the previous selection when the toggle is deselected', () => {
+      // Clicking the active toggle in a mat-button-toggle-group deselects it,
+      // emitting change with value undefined.
+      const ratingService = TestBed.inject(LearningRatingService);
+      const upsertSpy = vi.spyOn(ratingService, 'upsertRating');
+      component.studyContentId = 1;
+      const group = { value: undefined as unknown };
+      const event = { value: undefined, source: { value: 2, buttonToggleGroup: group } } as any;
+
+      component.onContentRatingChanged({ id: '10' } as any, event);
+
+      expect(upsertSpy).not.toHaveBeenCalled();
+      expect(group.value).toBe(2);
     });
   });
 });

--- a/src/app/pages/translate-exercises/translate-exercises.component.ts
+++ b/src/app/pages/translate-exercises/translate-exercises.component.ts
@@ -353,7 +353,13 @@ export class TranslateExercisesComponent implements OnInit {
   }
 
   onContentRatingChanged(item: LearnEnglishSentFileItem, event: MatButtonToggleChange) {
-    if (this.studyContentId <= 0 || item.id === undefined || event.value < 1) {
+    if (event.value === undefined || event.value === null || event.value < 1) {
+      // Clicking the active toggle deselects it (value becomes undefined).
+      // There is no "clear rating" operation, so restore the previous selection.
+      event.source.buttonToggleGroup.value = event.source.value;
+      return;
+    }
+    if (this.studyContentId <= 0 || item.id === undefined) {
       return;
     }
     const numId = parseInt(item.id, 10);

--- a/src/app/pages/vocabulary-exercises/vocabulary-exercises.component.html
+++ b/src/app/pages/vocabulary-exercises/vocabulary-exercises.component.html
@@ -36,7 +36,7 @@
         </div>
 
         <div class="vocabulary-rating-container">
-          <mat-button-toggle-group [(ngModel)]="studyQueues[currentStudyCursor].rating" aria-label="Rating" (change)="onRatingChanged(studyQueues[currentStudyCursor])">
+          <mat-button-toggle-group [(ngModel)]="studyQueues[currentStudyCursor].rating" aria-label="Rating" (change)="onRatingChanged(studyQueues[currentStudyCursor], $event)">
             <mat-button-toggle [value]="1">1</mat-button-toggle>
             <mat-button-toggle [value]="2">2</mat-button-toggle>
             <mat-button-toggle [value]="3">3</mat-button-toggle>

--- a/src/app/pages/vocabulary-exercises/vocabulary-exercises.component.spec.ts
+++ b/src/app/pages/vocabulary-exercises/vocabulary-exercises.component.spec.ts
@@ -1975,6 +1975,40 @@ describe('VocabularyExercisesComponent', () => {
       expect(component.selection.isEmpty()).toBe(true);
     });
   });
+
+  describe('rating deselection guards', () => {
+    it('onContentRatingChanged should not save and should restore selection on deselect', () => {
+      // Clicking the active toggle in a mat-button-toggle-group deselects it,
+      // emitting change with value undefined.
+      component.studyContentId = 1;
+      const group = { value: undefined as unknown };
+      const event = { value: undefined, source: { value: 4, buttonToggleGroup: group } } as any;
+
+      component.onContentRatingChanged({ id: 10 } as any, event);
+
+      expect(mockRatingService.upsertRating).not.toHaveBeenCalled();
+      expect(group.value).toBe(4);
+    });
+
+    it('onRatingChanged should not save and should restore model and selection on deselect', () => {
+      component.studyContentId = 1;
+      const item: StudyQueueItem = {
+        enword: 'hello',
+        cnword: '你好',
+        audiofile: '',
+        rating: undefined as unknown as number,
+        itemId: 10,
+      };
+      const group = { value: undefined as unknown };
+      const event = { value: undefined, source: { value: 4, buttonToggleGroup: group } } as any;
+
+      component.onRatingChanged(item, event);
+
+      expect(mockRatingService.upsertRating).not.toHaveBeenCalled();
+      expect(item.rating).toBe(4);
+      expect(group.value).toBe(4);
+    });
+  });
 });
 
 describe('VocabularyExercisesStudyOptionsDialogComponent', () => {

--- a/src/app/pages/vocabulary-exercises/vocabulary-exercises.component.ts
+++ b/src/app/pages/vocabulary-exercises/vocabulary-exercises.component.ts
@@ -281,7 +281,13 @@ export class VocabularyExercisesComponent implements OnInit {
   }
 
   onContentRatingChanged(item: LearnEnglishWordFileItem, event: MatButtonToggleChange) {
-    if (this.studyContentId <= 0 || item.id === undefined || event.value < 1) {
+    if (event.value === undefined || event.value === null || event.value < 1) {
+      // Clicking the active toggle deselects it (value becomes undefined).
+      // There is no "clear rating" operation, so restore the previous selection.
+      event.source.buttonToggleGroup.value = event.source.value;
+      return;
+    }
+    if (this.studyContentId <= 0 || item.id === undefined) {
       return;
     }
 
@@ -682,7 +688,17 @@ export class VocabularyExercisesComponent implements OnInit {
     this.cdr.markForCheck();
   }
 
-  onRatingChanged(item: StudyQueueItem) {
+  // `event` is undefined for keyboard-driven rating changes (arrow keys / 1-5),
+  // which set item.rating directly and cannot produce a deselection.
+  onRatingChanged(item: StudyQueueItem, event?: MatButtonToggleChange) {
+    if (event !== undefined && (event.value === undefined || event.value === null || event.value < 1)) {
+      // Clicking the active toggle deselects it (value becomes undefined); the
+      // two-way ngModel has already written that undefined into item.rating.
+      // There is no "clear rating" operation, so restore both model and view.
+      item.rating = event.source.value;
+      event.source.buttonToggleGroup.value = event.source.value;
+      return;
+    }
     if (this.studyContentId <= 0 || item.itemId === undefined || item.rating < 1) {
       return;
     }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,8 +1,8 @@
 export const environment = {
   homeurl: 'https://www.alvachien.com/learning',
   production: true,
-  releasedate: '2026-07-14',
-  version: '1.8.422',
+  releasedate: '2026-07-24',
+  version: '1.8.423',
   apiUrl: 'https://www.alvachien.com/learningutil',
   pageTitle: 'Knowledge Builder',
   loginRequired: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,8 +6,8 @@
 export const environment = {
   homeurl: 'http://localhost:29800',
   production: false,
-  releasedate: '2026-07-14',
-  version: '1.8.422',
+  releasedate: '2026-07-24',
+  version: '1.8.423',
   apiUrl: 'https://localhost:7135',
   pageTitle: 'Knowledge Builder',
   loginRequired: true,


### PR DESCRIPTION
## Problem

In the rating column of the learning pages (chinese-exercises, knowledge-exercises-list, translate-exercises, vocabulary-exercises), clicking the already-active toggle of a `mat-button-toggle-group` deselects it and emits `change` with `value === undefined`. The guard `event.value < 1` did not catch this (`undefined < 1` is `false` in JS), so an empty rating was sent to the API, which rejected it with a 400 — silently, since failures were only logged to the console.

## Changes

- All four rating-column handlers now detect deselection (`value === undefined || value === null || value < 1`), skip the API call, and restore the previous toggle selection in the UI.
- The vocabulary study-queue rating (`onRatingChanged`, two-way `ngModel`) got the same fix; the template now passes ``, and keyboard-driven rating changes (arrow keys / 1-5) keep working via an optional event parameter.
- Added 6 regression tests across the four pages.
- Bump version to 1.8.423, releasedate 2026-07-24.

## Verification

- `tsc --noEmit` clean; `ng test --watch=false`: 1357 passed, 0 failed.

Backend counterpart (root cause of ratings "lost after reload"): alvachien/aclearningutil#3.